### PR TITLE
Photo actions fixed for Firefox #56

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ TODO.md
 
 # To keep the `./uploads` directory (for the uploads)
 !uploads/.gitkeep
+
+.idea

--- a/static/js/image.js
+++ b/static/js/image.js
@@ -131,16 +131,16 @@ function sortImages() {
 }
 
 function makeImagePublic(event) {
-	var imageBox = event.path[4];
+	var imageBox = (event.path || (event.composedPath && event.composedPath()))[4];
 	var id = imageBox.getAttribute('image_id');
 
 	// the user might have clicked on the `div`
-	// and we are using `event.path` to manipulate data
+	// and we are using `(event.path || (event.composedPath && event.composedPath()))` to manipulate data
 	// so `id` can be `null`
 	if (!id)
 		return;
 
-	var img = event.path[0];
+	var img = (event.path || (event.composedPath && event.composedPath()))[0];
 	var value = imageBox.getAttribute('visibility') == 'public' ? 'private' : 'public';
 
 	let json = JSON.stringify({
@@ -173,17 +173,17 @@ function makeImagePublic(event) {
 }
 
 function likeImage(event) {
-	var imageBox = event.path[4];
+	var imageBox = (event.path || (event.composedPath && event.composedPath()))[4];
 	var id = imageBox.getAttribute('image_id');
 
 	// the user might have clicked on the `div`
-	// and we are using `event.path` to manipulate data
+	// and we are using `(event.path || (event.composedPath && event.composedPath()))` to manipulate data
 	// so `id` can be `null`
 	if (!id)
 		return;
 
-	var likeButton = event.path[1];
-	var likes = event.path[2].children[0];
+	var likeButton = (event.path || (event.composedPath && event.composedPath()))[1];
+	var likes = (event.path || (event.composedPath && event.composedPath()))[2].children[0];
 	var value = !(likeButton.getAttribute('liked') == 'true');
 
 	let json = JSON.stringify({
@@ -222,11 +222,11 @@ function likeImage(event) {
 }
 
 function deleteImage(event) {
-	var imageBox = event.path[4];
+	var imageBox = (event.path || (event.composedPath && event.composedPath()))[4];
 	var id = imageBox.getAttribute('image_id');
 
 	// the user might have clicked on the `div`
-	// and we are using `event.path` to manipulate data
+	// and we are using `(event.path || (event.composedPath && event.composedPath()))` to manipulate data
 	// so `id` can be `null`
 	if (!id)
 		return;


### PR DESCRIPTION
Issue: 56

Fixes #56

#### Short description of what this resolves:
**Tested on Firefox**
There were issues with `event.path` object used when an image is liked or deleted.
This object wasn't available in Firefox and this PR fixes that by using `event.composedPath()` as a fallback